### PR TITLE
replace "create or replace" with "drop/create" for triggers

### DIFF
--- a/build/dev/docker/docker-compose.yaml
+++ b/build/dev/docker/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '2.4'
 services:
   postgres:
-    image: postgres
+    image: postgres:13
     volumes:
       - ./initdb.d:/docker-entrypoint-initdb.d:ro
     ports:

--- a/migrations/postgres/000001_create-initial-tables.up.sql
+++ b/migrations/postgres/000001_create-initial-tables.up.sql
@@ -95,21 +95,25 @@ BEGIN
 END $$;
 
 -- triggers
-CREATE OR REPLACE TRIGGER set_storage_buckets_updated_at
+DROP TRIGGER IF EXISTS set_storage_buckets_updated_at ON storage.buckets;
+CREATE TRIGGER set_storage_buckets_updated_at
   BEFORE UPDATE ON storage.buckets
   FOR EACH ROW
   EXECUTE FUNCTION storage.set_current_timestamp_updated_at ();
 
-CREATE OR REPLACE TRIGGER set_storage_files_updated_at
+DROP TRIGGER IF EXISTS set_storage_files_updated_at ON storage.files;
+CREATE TRIGGER set_storage_files_updated_at
   BEFORE UPDATE ON storage.files
   FOR EACH ROW
   EXECUTE FUNCTION storage.set_current_timestamp_updated_at ();
 
+DROP TRIGGER IF EXISTS check_default_bucket_delete ON storage.buckets;
 CREATE TRIGGER check_default_bucket_delete
   BEFORE DELETE ON storage.buckets
   FOR EACH ROW
     EXECUTE PROCEDURE storage.protect_default_bucket_delete ();
 
+DROP TRIGGER IF EXISTS check_default_bucket_update ON storage.buckets;
 CREATE TRIGGER check_default_bucket_update
   BEFORE UPDATE ON storage.buckets
   FOR EACH ROW


### PR DESCRIPTION
- the syntax `create or replace` on triggers is only available in Postgres 14.
- replace it with `drop` followed by `create` so that older versions of Postgres are supported.