### PR TITLE
feat: added backwards compatibility with former storage

### DIFF
--- a/controller/errors.go
+++ b/controller/errors.go
@@ -7,6 +7,12 @@ import (
 )
 
 var (
+	ErrMultipartFormFileNotFound = &APIError{
+		http.StatusBadRequest,
+		"file[] not found in Multipart form",
+		errors.New("file[] not found in Multipart form"), // nolint
+		nil,
+	}
 	ErrMultipartFileWrong = &APIError{
 		http.StatusBadRequest,
 		"wrong file data in multipart form, one needs to be specified",

--- a/controller/update_file.go
+++ b/controller/update_file.go
@@ -35,7 +35,7 @@ func updateFileParseRequest(ctx *gin.Context) (fileData, *APIError) {
 	res.header = file[0]
 
 	metadata, ok := form.Value["metadata"]
-	if ok {
+	if ok { // nolint: nestif
 		if len(metadata) != len(file) {
 			return fileData{}, ErrMetadataLength
 		}
@@ -47,7 +47,16 @@ func updateFileParseRequest(ctx *gin.Context) (fileData, *APIError) {
 
 		res.Name = d.Name
 	} else {
-		res.Name = res.header.Filename
+		fileName := ctx.Request.Header.Get("x-nhost-file-name")
+		if fileName == "" {
+			fileName = res.header.Filename
+		} else {
+			ctx.Writer.Header().Add(
+				"X-deprecation-warning-old-upload-file-method",
+				"please, update the SDK to leverage new API endpoint or read the API docs to adapt your code",
+			)
+		}
+		res.Name = fileName
 	}
 
 	return res, nil

--- a/example_curl.sh
+++ b/example_curl.sh
@@ -7,6 +7,9 @@ BUCKET=default
 FILE_ID=55af1e60-0f28-454e-885e-ea6aab2bb288
 ETAG=\"588be441fe7a59460850b0aa3e1c5a65\"
 
+# we sleep for 1s to make sure a drift in the clocks between client/server doesn't
+# lead to a JWTIssuedAtFuture error
+sleep 1
 
 output=`curl $URL/ \
   -v \


### PR DESCRIPTION
## Description

To simplify migration to new storage we are adding compatibility with former storage. If we detect the user is using the old version of the API we add a custom header warning about the deprecation of the API endpoint. We are also avoiding documenting these changes as this API shouldn't be used and will be removed eventually