### PR TITLE
fix: use admin secret to update metadata when uploading files

### DIFF
--- a/controller/upload_file.go
+++ b/controller/upload_file.go
@@ -99,7 +99,7 @@ func (ctrl *Controller) upload(
 		metadata, apiErr := ctrl.metadataStorage.PopulateMetadata(
 			ctx,
 			file.ID, file.Name, file.header.Size, bucket.ID, etag, true, contentType,
-			request.headers,
+			http.Header{"x-hasura-admin-secret": []string{ctrl.hasuraAdminSecret}},
 		)
 		if apiErr != nil {
 			return filesMetadata, apiErr.ExtendError(fmt.Sprintf("problem populating file metadata for file %s", file.Name))

--- a/controller/upload_file.go
+++ b/controller/upload_file.go
@@ -92,7 +92,11 @@ func (ctrl *Controller) upload(
 
 		etag, contentType, err := ctrl.uploadSingleFile(file, file.ID)
 		if err != nil {
-			_, _ = ctrl.metadataStorage.DeleteFileByID(ctx, file.ID, request.headers)
+			_, _ = ctrl.metadataStorage.DeleteFileByID(
+				ctx,
+				file.ID,
+				http.Header{"x-hasura-admin-secret": []string{ctrl.hasuraAdminSecret}},
+			)
 			return filesMetadata, InternalServerError(fmt.Errorf("problem processing file %s: %w", file.Name, err))
 		}
 


### PR DESCRIPTION
goal is to avoid having to give update permissions to users for uploading users