### PR TITLE
chore: improve build times using nix container by caching vips build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,14 @@ dev-env-build: build-docker-image  ## Builds development environment
 	docker-compose -f ${DOCKER_DEV_ENV_PATH}/docker-compose.yaml build
 
 
+.PHONY: dev-env-build-builder
+dev-env-build-builder:
+	docker build \
+		-t dbarroso/hasura-storage-builder:latest \
+		-f build/nix.Dockerfile \
+		.
+
+
 .PHONY: dev-env-shell
 dev-env-shell:  ## Starts a shell in a dockerized build environment
 	docker run --rm -it \
@@ -86,7 +94,7 @@ dev-env-shell:  ## Starts a shell in a dockerized build environment
 		-w /build \
 		--entrypoint sh \
 		dbarroso/hasura-storage-builder:latest \
-		-c "nix develop .#default"
+		-c "nix develop"
 
 
 .PHONY: dev-jwt

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,17 @@ dev-env-build: build-docker-image  ## Builds development environment
 	docker-compose -f ${DOCKER_DEV_ENV_PATH}/docker-compose.yaml build
 
 
+.PHONY: dev-env-shell
+dev-env-shell:  ## Starts a shell in a dockerized build environment
+	docker run --rm -it \
+		-v /var/run/docker.sock:/var/run/docker.sock \
+		-v $(PWD):/build \
+		-w /build \
+		--entrypoint sh \
+		dbarroso/hasura-storage-builder:latest \
+		-c "nix develop .#default"
+
+
 .PHONY: dev-jwt
 dev-jwt:  ## return a jwt valid for development environment
 	@sh ./$(DEV_ENV_PATH)/jwt-gen/get-jwt.sh

--- a/build/nix-docker-image.sh
+++ b/build/nix-docker-image.sh
@@ -27,5 +27,5 @@ docker run --rm -it \
     -v $PWD:/build \
     -w /build \
     --entrypoint sh \
-    dbarroso/nix:2.6.0 \
+    dbarroso/hasura-storage-builder:latest \
         -c "nix build .\\#dockerImage --print-build-logs && docker load < result"

--- a/build/nix-docker-image.sh
+++ b/build/nix-docker-image.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+BUILDER_NAME=hasura-stora-builder
 
 which nix > /dev/null
 

--- a/build/nix.Dockerfile
+++ b/build/nix.Dockerfile
@@ -1,0 +1,13 @@
+FROM nixos/nix:2.8.0
+
+RUN echo -e "experimental-features = nix-command flakes \n\
+filter-syscalls = false" >> /etc/nix/nix.conf
+
+WORKDIR /tmp/initial-cache
+
+ADD flake.* .
+ADD nix nix
+
+RUN nix develop && nix-env -iA nixpkgs.docker-client
+
+WORKDIR /build


### PR DESCRIPTION
This PR adds two improvements for non-nix users:

1. It uses a docker image with nix and vips already pre-built to build hasura-storage
2. It adds a make target `dev-env-shell` that starts the same docker image and gives you a shell. This means you get access to the exact build environment so you can run tests or build the software by hand without having to worry about differences between your environment and the build environment.