### PR TITLE
create bucket dir before start minio

### DIFF
--- a/build/dev/docker/docker-compose.yaml
+++ b/build/dev/docker/docker-compose.yaml
@@ -38,7 +38,7 @@ services:
       MINIO_ROOT_USER: ${S3_ACCESS_KEY:-5a7bdb5f42c41e0622bf61d6e08d5537}
       MINIO_ROOT_PASSWORD: ${S3_SECRET_KEY:-9e1c40c65a615a5b52f52aeeaf549944ec53acb1dff4a0bf01fb58e969f915c8}
     entrypoint: sh
-    command: '-c ''mkdir -p /tmp/default && server --address 0.0.0.0:9000 --console-address 0.0.0.0:32765 /tmp'''
+    command: '-c ''mkdir -p /tmp/default && /opt/bin/minio server --address 0.0.0.0:9000 --console-address 0.0.0.0:32765 /tmp'''
     ports:
       - '9000:9000'
       - '32765:32765'

--- a/build/dev/docker/docker-compose.yaml
+++ b/build/dev/docker/docker-compose.yaml
@@ -37,7 +37,8 @@ services:
     environment:
       MINIO_ROOT_USER: ${S3_ACCESS_KEY:-5a7bdb5f42c41e0622bf61d6e08d5537}
       MINIO_ROOT_PASSWORD: ${S3_SECRET_KEY:-9e1c40c65a615a5b52f52aeeaf549944ec53acb1dff4a0bf01fb58e969f915c8}
-    command: server --address 0.0.0.0:9000 --console-address 0.0.0.0:32765 /tmp
+    entrypoint: sh
+    command: '-c ''mkdir -p /tmp/default && server --address 0.0.0.0:9000 --console-address 0.0.0.0:32765 /tmp'''
     ports:
       - '9000:9000'
       - '32765:32765'


### PR DESCRIPTION
## Description
If dont create dir, and after start try example_curl.sh - hasura-storage will fail to write file into the bucket with error bucket does not exists.
## Problem
minio does not contain default bucket

## Solution
change minio start command to create bucket dir

