### PR TITLE
feat: added x-hasura-role to allowed headers in CORS

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -127,6 +127,7 @@ func (ctrl *Controller) SetupRouter(
 		AllowHeaders: []string{
 			"Authorization", "Origin", "if-match", "if-none-match", "if-modified-since", "if-unmodified-since",
 			"x-hasura-admin-secret", "x-nhost-bucket-id", "x-nhost-file-name", "x-nhost-file-id",
+			"x-hasura-role",
 		},
 		// AllowWildcard: true,
 		ExposeHeaders: []string{


### PR DESCRIPTION
## Description

Adds `x-hasura-role` to the list of allowed headers for CORS.

## Problem

For web requests made in single-page applications using a JWT with a desired role other than that specified in `x-hasura-default-role`: specifying the header with value `'X-Hasura-Role': 'desired-role'` is required to transact. Without this header in the allowed list for CORS, the preflight check made in the browser will fail the transaction.

## Solution

Added "x-hasura-role" to the list of allowed headers.

## Notes

To test this:

- Generate a jwt with a default permission other than admin as the default
  - ```diff
    diff --git a/build/dev/jwt-gen/main.go b/build/dev/jwt-gen/main.go
    index d02a9fc..659369c 100644
    --- a/build/dev/jwt-gen/main.go
    +++ b/build/dev/jwt-gen/main.go
    @@ -40,8 +40,10 @@ func main() {
                    "https://hasura.io/jwt/claims": map[string]interface{}{
                            "x-hasura-allowed-roles": []string{
                                    "admin",
    +                               "staff",
    +                               "public",
                            },
    -                       "x-hasura-default-role":     "admin",
    +                       "x-hasura-default-role":     "public",
                            "x-hasura-user-id":          "ab5ba58e-932a-40dc-87e8-733998794ec2",
                            "x-hasura-user-isAnonymous": "false",
    ```

- Then allow permissions for the role being tested in the hasura `storage_files` table using the web console
- Then make a single page web app using the development stack
  - Simple app I made to test with: [myapp.zip](https://github.com/nhost/hasura-storage/files/9853806/myapp.zip)
  - Run `npm install` then `npm run dev` to run the app
  - Navigate to the app at the URL listed and open the console for debugging
  - Attempt to upload a file with the JWT using a role without insert permissions.
  - Change the role used in `myapp/src/lib/Counter.svelte` to use a role with insert permissions
  - At no point should you get CORS errors in the console and files should upload when insert permissions are allocated for the selected role.
  - Revert to main and test the file upload again to see the CORS errors.

Closes #119 
