### PR TITLE
feat: respect specified content-type if specified and is other than application/octet-stream

### DIFF
--- a/controller/update_file_test.go
+++ b/controller/update_file_test.go
@@ -68,7 +68,7 @@ func TestUpdateFile(t *testing.T) {
 			logger.SetLevel(logrus.ErrorLevel)
 
 			file := fakeFile{
-				"some content", fakeFileMetadata{"a_file.txt", uuid.New().String()},
+				"some content", "", fakeFileMetadata{"a_file.txt", uuid.New().String()},
 			}
 
 			c := gomock.NewController(t)

--- a/controller/upload_file.go
+++ b/controller/upload_file.go
@@ -47,13 +47,18 @@ func (ctrl *Controller) getMultipartFile(file fileData) (multipart.File, string,
 		return nil, "", InternalServerError(fmt.Errorf("problem opening file %s: %w", file.Name, err))
 	}
 
-	contentType, err := mimetype.DetectReader(fileContent)
+	contentType := file.header.Header.Get("Content-Type")
+	if contentType != "" && contentType != "application/octet-stream" {
+		return fileContent, contentType, nil
+	}
+
+	mt, err := mimetype.DetectReader(fileContent)
 	if err != nil {
 		return nil, "",
 			InternalServerError(fmt.Errorf("problem figuring out content type for file %s: %w", file.Name, err))
 	}
 
-	return fileContent, contentType.String(), nil
+	return fileContent, mt.String(), nil
 }
 
 func (ctrl *Controller) upload(


### PR DESCRIPTION
Up until now we were always ignoring it and detecting the type automatically. Now we will only attempt to detect the type automatically if it isn't specified or if it is "application/octet-stream".