### PR TITLE
feat: allow configuration of cors domains and credentials

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -144,7 +144,7 @@ func (ctrl *Controller) SetupRouter(
 		MaxAge: 12 * time.Hour, //nolint: gomnd
 	}
 
-	if corsAllowCredentials == true {
+	if corsAllowCredentials {
 		corsConfig.AllowCredentials = true
 	}
 

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -6,8 +6,6 @@ import (
 	"io"
 	"net/http"
 	"time"
-	"os"
-	"strings"
 
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
@@ -113,7 +111,11 @@ func New(
 }
 
 func (ctrl *Controller) SetupRouter(
-	trustedProxies []string, apiRootPrefix string, middleware ...gin.HandlerFunc,
+	trustedProxies []string,
+	apiRootPrefix string,
+	corsOrigins []string,
+	corsAllowCredentials bool,
+	middleware ...gin.HandlerFunc,
 ) (*gin.Engine, error) {
 	router := gin.New()
 	if err := router.SetTrustedProxies(trustedProxies); err != nil {
@@ -128,7 +130,25 @@ func (ctrl *Controller) SetupRouter(
 		router.Use(mw)
 	}
 
-	router.Use(cors.New(getCorsConfig()))
+	corsConfig := cors.Config{
+		AllowOrigins: corsOrigins,
+		AllowMethods: []string{"GET", "PUT", "POST", "HEAD", "DELETE"},
+		AllowHeaders: []string{
+			"Authorization", "Origin", "if-match", "if-none-match", "if-modified-since", "if-unmodified-since",
+			"x-hasura-admin-secret", "x-nhost-bucket-id", "x-nhost-file-name", "x-nhost-file-id",
+			"x-hasura-role",
+		},
+		ExposeHeaders: []string{
+			"Content-Length", "Content-Type", "Cache-Control", "ETag", "Last-Modified", "X-Error",
+		},
+		MaxAge: 12 * time.Hour, //nolint: gomnd
+	}
+
+	if corsAllowCredentials == true {
+		corsConfig.AllowCredentials = true
+	}
+
+	router.Use(cors.New(corsConfig))
 
 	router.GET("/healthz", ctrl.Health)
 
@@ -164,30 +184,4 @@ func (ctrl *Controller) Health(ctx *gin.Context) {
 	ctx.JSON(http.StatusOK, gin.H{
 		"healthz": "ok",
 	})
-}
-
-func getCorsConfig() cors.Config {
-	config := cors.Config{
-		AllowOrigins: []string{"*"},
-		AllowMethods: []string{"GET", "PUT", "POST", "HEAD", "DELETE"},
-		AllowHeaders: []string{
-			"Authorization", "Origin", "if-match", "if-none-match", "if-modified-since", "if-unmodified-since",
-			"x-hasura-admin-secret", "x-nhost-bucket-id", "x-nhost-file-name", "x-nhost-file-id",
-			"x-hasura-role",
-		},
-		ExposeHeaders: []string{
-			"Content-Length", "Content-Type", "Cache-Control", "ETag", "Last-Modified", "X-Error",
-		},
-		MaxAge: 12 * time.Hour, //nolint: gomnd
-	}
-	
-	if os.Getenv("CORS_ALLOW_ORIGINS") != "" {
-		config.AllowOrigins = strings.Split(os.Getenv("CORS_ALLOW_ORIGINS"), ",")
-	}
-
-	if os.Getenv("CORS_ALLOW_CREDENTIALS") == "true" {
-		config.AllowCredentials = true
-	}
-
-	return config
 }

--- a/controller/delete_broken_metadata_test.go
+++ b/controller/delete_broken_metadata_test.go
@@ -103,7 +103,7 @@ func TestDeleteBrokenMetadata(t *testing.T) {
 
 			ctrl := controller.New("http://asd", "/v1", "asdasd", metadataStorage, contentStorage, nil, logger)
 
-			router, _ := ctrl.SetupRouter(nil, "/v1", ginLogger(logger))
+			router, _ := ctrl.SetupRouter(nil, "/v1", []string{}, false, ginLogger(logger))
 
 			responseRecorder := httptest.NewRecorder()
 

--- a/controller/delete_broken_metadata_test.go
+++ b/controller/delete_broken_metadata_test.go
@@ -103,7 +103,7 @@ func TestDeleteBrokenMetadata(t *testing.T) {
 
 			ctrl := controller.New("http://asd", "/v1", "asdasd", metadataStorage, contentStorage, nil, logger)
 
-			router, _ := ctrl.SetupRouter(nil, "/v1", []string{}, false, ginLogger(logger))
+			router, _ := ctrl.SetupRouter(nil, "/v1", []string{"*"}, false, ginLogger(logger))
 
 			responseRecorder := httptest.NewRecorder()
 

--- a/controller/delete_file_test.go
+++ b/controller/delete_file_test.go
@@ -53,7 +53,7 @@ func TestDeleteFile(t *testing.T) {
 
 			ctrl := controller.New("http://asd", "/v1", "asdasd", metadataStorage, contentStorage, nil, logger)
 
-			router, _ := ctrl.SetupRouter(nil, "/v1", []string{}, false, ginLogger(logger))
+			router, _ := ctrl.SetupRouter(nil, "/v1", []string{"*"}, false, ginLogger(logger))
 
 			responseRecorder := httptest.NewRecorder()
 

--- a/controller/delete_file_test.go
+++ b/controller/delete_file_test.go
@@ -53,7 +53,7 @@ func TestDeleteFile(t *testing.T) {
 
 			ctrl := controller.New("http://asd", "/v1", "asdasd", metadataStorage, contentStorage, nil, logger)
 
-			router, _ := ctrl.SetupRouter(nil, "/v1", ginLogger(logger))
+			router, _ := ctrl.SetupRouter(nil, "/v1", []string{}, false, ginLogger(logger))
 
 			responseRecorder := httptest.NewRecorder()
 

--- a/controller/delete_orphans_test.go
+++ b/controller/delete_orphans_test.go
@@ -75,7 +75,7 @@ func TestDeleteOrphans(t *testing.T) {
 
 			ctrl := controller.New("http://asd", "/v1", "asdasd", metadataStorage, contentStorage, nil, logger)
 
-			router, _ := ctrl.SetupRouter(nil, "/v1", []string{}, false, ginLogger(logger))
+			router, _ := ctrl.SetupRouter(nil, "/v1", []string{"*"}, false, ginLogger(logger))
 
 			responseRecorder := httptest.NewRecorder()
 

--- a/controller/delete_orphans_test.go
+++ b/controller/delete_orphans_test.go
@@ -75,7 +75,7 @@ func TestDeleteOrphans(t *testing.T) {
 
 			ctrl := controller.New("http://asd", "/v1", "asdasd", metadataStorage, contentStorage, nil, logger)
 
-			router, _ := ctrl.SetupRouter(nil, "/v1", ginLogger(logger))
+			router, _ := ctrl.SetupRouter(nil, "/v1", []string{}, false, ginLogger(logger))
 
 			responseRecorder := httptest.NewRecorder()
 

--- a/controller/get_file.go
+++ b/controller/get_file.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strconv"
 	"time"
 
@@ -222,7 +223,7 @@ func (ctrl *Controller) getFileProcess(ctx *gin.Context) (*FileResponse, *APIErr
 
 	if response.statusCode == http.StatusOK {
 		// if we want to download files at some point prepend `attachment;` before filename
-		response.headers.Add("Content-Disposition", fmt.Sprintf(`inline; filename="%s"`, fileMetadata.Name))
+		response.headers.Add("Content-Disposition", fmt.Sprintf(`inline; filename="%s"`, url.QueryEscape(fileMetadata.Name)))
 	}
 
 	return response, nil

--- a/controller/get_file_information_test.go
+++ b/controller/get_file_information_test.go
@@ -146,7 +146,7 @@ func TestGetFileInfo(t *testing.T) {
 				logger,
 			)
 
-			router, _ := ctrl.SetupRouter(nil, "/v1", ginLogger(logger))
+			router, _ := ctrl.SetupRouter(nil, "/v1", []string{}, false, ginLogger(logger))
 
 			responseRecorder := httptest.NewRecorder()
 

--- a/controller/get_file_information_test.go
+++ b/controller/get_file_information_test.go
@@ -146,7 +146,7 @@ func TestGetFileInfo(t *testing.T) {
 				logger,
 			)
 
-			router, _ := ctrl.SetupRouter(nil, "/v1", []string{}, false, ginLogger(logger))
+			router, _ := ctrl.SetupRouter(nil, "/v1", []string{"*"}, false, ginLogger(logger))
 
 			responseRecorder := httptest.NewRecorder()
 

--- a/controller/get_file_presigned_url_test.go
+++ b/controller/get_file_presigned_url_test.go
@@ -92,7 +92,7 @@ func TestGetFilePresignedURL(t *testing.T) {
 
 			ctrl := controller.New("http://asd", "/v1", "asdasd", metadataStorage, contentStorage, nil, logger)
 
-			router, _ := ctrl.SetupRouter(nil, "/v1", ginLogger(logger))
+			router, _ := ctrl.SetupRouter(nil, "/v1", []string{}, false, ginLogger(logger))
 
 			responseRecorder := httptest.NewRecorder()
 

--- a/controller/get_file_presigned_url_test.go
+++ b/controller/get_file_presigned_url_test.go
@@ -92,7 +92,7 @@ func TestGetFilePresignedURL(t *testing.T) {
 
 			ctrl := controller.New("http://asd", "/v1", "asdasd", metadataStorage, contentStorage, nil, logger)
 
-			router, _ := ctrl.SetupRouter(nil, "/v1", []string{}, false, ginLogger(logger))
+			router, _ := ctrl.SetupRouter(nil, "/v1", []string{"*"}, false, ginLogger(logger))
 
 			responseRecorder := httptest.NewRecorder()
 

--- a/controller/get_file_test.go
+++ b/controller/get_file_test.go
@@ -78,7 +78,7 @@ func TestGetFile(t *testing.T) {
 
 			ctrl := controller.New("http://asd", "/v1", "asdasd", metadataStorage, contentStorage, nil, logger)
 
-			router, _ := ctrl.SetupRouter(nil, "/v1", []string{}, false, ginLogger(logger))
+			router, _ := ctrl.SetupRouter(nil, "/v1", []string{"*"}, false, ginLogger(logger))
 
 			responseRecorder := httptest.NewRecorder()
 

--- a/controller/get_file_test.go
+++ b/controller/get_file_test.go
@@ -78,7 +78,7 @@ func TestGetFile(t *testing.T) {
 
 			ctrl := controller.New("http://asd", "/v1", "asdasd", metadataStorage, contentStorage, nil, logger)
 
-			router, _ := ctrl.SetupRouter(nil, "/v1", ginLogger(logger))
+			router, _ := ctrl.SetupRouter(nil, "/v1", []string{}, false, ginLogger(logger))
 
 			responseRecorder := httptest.NewRecorder()
 

--- a/controller/list_broken_metadata_test.go
+++ b/controller/list_broken_metadata_test.go
@@ -96,7 +96,7 @@ func TestListBrokenMetadata(t *testing.T) {
 
 			ctrl := controller.New("http://asd", "/v1", "asdasd", metadataStorage, contentStorage, nil, logger)
 
-			router, _ := ctrl.SetupRouter(nil, "/v1", []string{}, false, ginLogger(logger))
+			router, _ := ctrl.SetupRouter(nil, "/v1", []string{"*"}, false, ginLogger(logger))
 
 			responseRecorder := httptest.NewRecorder()
 

--- a/controller/list_broken_metadata_test.go
+++ b/controller/list_broken_metadata_test.go
@@ -96,7 +96,7 @@ func TestListBrokenMetadata(t *testing.T) {
 
 			ctrl := controller.New("http://asd", "/v1", "asdasd", metadataStorage, contentStorage, nil, logger)
 
-			router, _ := ctrl.SetupRouter(nil, "/v1", ginLogger(logger))
+			router, _ := ctrl.SetupRouter(nil, "/v1", []string{}, false, ginLogger(logger))
 
 			responseRecorder := httptest.NewRecorder()
 

--- a/controller/list_not_uploaded_test.go
+++ b/controller/list_not_uploaded_test.go
@@ -84,7 +84,7 @@ func TestListNotUploaded(t *testing.T) {
 
 			ctrl := controller.New("http://asd", "/v1", "asdasd", metadataStorage, contentStorage, nil, logger)
 
-			router, _ := ctrl.SetupRouter(nil, "/v1", []string{}, false, ginLogger(logger))
+			router, _ := ctrl.SetupRouter(nil, "/v1", []string{"*"}, false, ginLogger(logger))
 
 			responseRecorder := httptest.NewRecorder()
 

--- a/controller/list_not_uploaded_test.go
+++ b/controller/list_not_uploaded_test.go
@@ -84,7 +84,7 @@ func TestListNotUploaded(t *testing.T) {
 
 			ctrl := controller.New("http://asd", "/v1", "asdasd", metadataStorage, contentStorage, nil, logger)
 
-			router, _ := ctrl.SetupRouter(nil, "/v1", ginLogger(logger))
+			router, _ := ctrl.SetupRouter(nil, "/v1", []string{}, false, ginLogger(logger))
 
 			responseRecorder := httptest.NewRecorder()
 

--- a/controller/list_orphans_test.go
+++ b/controller/list_orphans_test.go
@@ -73,7 +73,7 @@ func TestListOrphans(t *testing.T) {
 
 			ctrl := controller.New("http://asd", "/v1", "asdasd", metadataStorage, contentStorage, nil, logger)
 
-			router, _ := ctrl.SetupRouter(nil, "/v1", ginLogger(logger))
+			router, _ := ctrl.SetupRouter(nil, "/v1", []string{}, false, ginLogger(logger))
 
 			responseRecorder := httptest.NewRecorder()
 

--- a/controller/list_orphans_test.go
+++ b/controller/list_orphans_test.go
@@ -73,7 +73,7 @@ func TestListOrphans(t *testing.T) {
 
 			ctrl := controller.New("http://asd", "/v1", "asdasd", metadataStorage, contentStorage, nil, logger)
 
-			router, _ := ctrl.SetupRouter(nil, "/v1", []string{}, false, ginLogger(logger))
+			router, _ := ctrl.SetupRouter(nil, "/v1", []string{"*"}, false, ginLogger(logger))
 
 			responseRecorder := httptest.NewRecorder()
 

--- a/controller/response.go
+++ b/controller/response.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -81,7 +82,7 @@ func (r *FileResponse) Write(ctx *gin.Context) {
 	ctx.Header("Etag", r.etag)
 
 	if r.body != nil && (r.statusCode == http.StatusOK || r.statusCode == http.StatusPartialContent) {
-		ctx.Writer.Header().Set("Content-Disposition", fmt.Sprintf(`inline; filename="%s"`, r.name))
+		ctx.Writer.Header().Set("Content-Disposition", fmt.Sprintf(`inline; filename="%s"`, url.QueryEscape(r.name)))
 
 		_, err := io.Copy(ctx.Writer, r.body)
 		if err != nil {

--- a/controller/update_file_test.go
+++ b/controller/update_file_test.go
@@ -148,7 +148,7 @@ func TestUpdateFile(t *testing.T) {
 
 			ctrl := controller.New("http://asd", "/v1", "asdasd", metadataStorage, contentStorage, nil, logger)
 
-			router, _ := ctrl.SetupRouter(nil, "/v1", []string{}, false, ginLogger(logger))
+			router, _ := ctrl.SetupRouter(nil, "/v1", []string{"*"}, false, ginLogger(logger))
 
 			body, contentType := createUpdateMultiForm(t, file)
 

--- a/controller/update_file_test.go
+++ b/controller/update_file_test.go
@@ -148,7 +148,7 @@ func TestUpdateFile(t *testing.T) {
 
 			ctrl := controller.New("http://asd", "/v1", "asdasd", metadataStorage, contentStorage, nil, logger)
 
-			router, _ := ctrl.SetupRouter(nil, "/v1", ginLogger(logger))
+			router, _ := ctrl.SetupRouter(nil, "/v1", []string{}, false, ginLogger(logger))
 
 			body, contentType := createUpdateMultiForm(t, file)
 

--- a/controller/upload_file_test.go
+++ b/controller/upload_file_test.go
@@ -231,7 +231,7 @@ func TestUploadFile(t *testing.T) {
 
 			ctrl := controller.New("http://asd", "/v1", "asdasd", metadataStorage, contentStorage, nil, logger)
 
-			router, _ := ctrl.SetupRouter(nil, "/v1", ginLogger(logger))
+			router, _ := ctrl.SetupRouter(nil, "/v1", []string{}, false, ginLogger(logger))
 
 			body, contentType := createMultiForm(t, files...)
 

--- a/controller/upload_file_test.go
+++ b/controller/upload_file_test.go
@@ -231,7 +231,7 @@ func TestUploadFile(t *testing.T) {
 
 			ctrl := controller.New("http://asd", "/v1", "asdasd", metadataStorage, contentStorage, nil, logger)
 
-			router, _ := ctrl.SetupRouter(nil, "/v1", []string{}, false, ginLogger(logger))
+			router, _ := ctrl.SetupRouter(nil, "/v1", []string{"*"}, false, ginLogger(logger))
 
 			body, contentType := createMultiForm(t, files...)
 


### PR DESCRIPTION
## Description
<!--
Use one of the following title prefix to categorize the pull request:
feat:   mark this pull request as a feature
fix:    mark this pull request as a bug fix
chore:  mark this pull request as a maintenance item
-->
## Problem
For applications that use cookie-based auth, CORS domain wildcards are not allowed. Need to specify explicit domains instead. Plus, `Access-Control-Allow-Credentials` must be set to `true`.

## Solution
This makes CORS domains optionally configurable via `CORS_ALLOW_ORIGINS`, same for `Access-Control-Allow-Credentials` via `CORS_ALLOW_CREDENTIALS`. If no configuration is specified, current behavior is kept.

