### PR TITLE
Fix/url safe filename

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -6,8 +6,6 @@ import (
 	"io"
 	"net/http"
 	"time"
-	"os"
-	"strings"
 
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
@@ -113,7 +111,11 @@ func New(
 }
 
 func (ctrl *Controller) SetupRouter(
-	trustedProxies []string, apiRootPrefix string, middleware ...gin.HandlerFunc,
+	trustedProxies []string,
+	apiRootPrefix string,
+	corsOrigins []string,
+	corsAllowCredentials bool,
+	middleware ...gin.HandlerFunc,
 ) (*gin.Engine, error) {
 	router := gin.New()
 	if err := router.SetTrustedProxies(trustedProxies); err != nil {
@@ -128,7 +130,25 @@ func (ctrl *Controller) SetupRouter(
 		router.Use(mw)
 	}
 
-	router.Use(cors.New(getCorsConfig()))
+	corsConfig := cors.Config{
+		AllowOrigins: corsOrigins,
+		AllowMethods: []string{"GET", "PUT", "POST", "HEAD", "DELETE"},
+		AllowHeaders: []string{
+			"Authorization", "Origin", "if-match", "if-none-match", "if-modified-since", "if-unmodified-since",
+			"x-hasura-admin-secret", "x-nhost-bucket-id", "x-nhost-file-name", "x-nhost-file-id",
+			"x-hasura-role",
+		},
+		ExposeHeaders: []string{
+			"Content-Length", "Content-Type", "Cache-Control", "ETag", "Last-Modified", "X-Error",
+		},
+		MaxAge: 12 * time.Hour, //nolint: gomnd
+	}
+
+	if corsAllowCredentials == true {
+		corsConfig.AllowCredentials = true
+	}
+
+	router.Use(cors.New(corsConfig))
 
 	router.GET("/healthz", ctrl.Health)
 
@@ -164,30 +184,4 @@ func (ctrl *Controller) Health(ctx *gin.Context) {
 	ctx.JSON(http.StatusOK, gin.H{
 		"healthz": "ok",
 	})
-}
-
-func getCorsConfig() cors.Config {
-	config := cors.Config{
-		AllowOrigins: []string{"*"},
-		AllowMethods: []string{"GET", "PUT", "POST", "HEAD", "DELETE"},
-		AllowHeaders: []string{
-			"Authorization", "Origin", "if-match", "if-none-match", "if-modified-since", "if-unmodified-since",
-			"x-hasura-admin-secret", "x-nhost-bucket-id", "x-nhost-file-name", "x-nhost-file-id",
-			"x-hasura-role",
-		},
-		ExposeHeaders: []string{
-			"Content-Length", "Content-Type", "Cache-Control", "ETag", "Last-Modified", "X-Error",
-		},
-		MaxAge: 12 * time.Hour, //nolint: gomnd
-	}
-	
-	if os.Getenv("CORS_ALLOW_ORIGINS") != "" {
-		config.AllowOrigins = strings.Split(os.Getenv("CORS_ALLOW_ORIGINS"), ",")
-	}
-
-	if os.Getenv("CORS_ALLOW_CREDENTIALS") == "true" {
-		config.AllowCredentials = true
-	}
-
-	return config
 }

--- a/controller/get_file.go
+++ b/controller/get_file.go
@@ -222,7 +222,7 @@ func (ctrl *Controller) getFileProcess(ctx *gin.Context) (*FileResponse, *APIErr
 	}
 
 	if response.statusCode == http.StatusOK {
-	    safeName := url.QueryEscape(fileMetadata.Name)
+		safeName := url.QueryEscape(fileMetadata.Name)
 
 		// if we want to download files at some point prepend `attachment;` before filename
 		response.headers.Add("Content-Disposition", fmt.Sprintf(`inline; filename="%s"`, safeName))

--- a/controller/get_file.go
+++ b/controller/get_file.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strconv"
 	"time"
 
@@ -221,8 +222,10 @@ func (ctrl *Controller) getFileProcess(ctx *gin.Context) (*FileResponse, *APIErr
 	}
 
 	if response.statusCode == http.StatusOK {
+	    safeName := url.QueryEscape(fileMetadata.Name)
+
 		// if we want to download files at some point prepend `attachment;` before filename
-		response.headers.Add("Content-Disposition", fmt.Sprintf(`inline; filename="%s"`, fileMetadata.Name))
+		response.headers.Add("Content-Disposition", fmt.Sprintf(`inline; filename="%s"`, safeName))
 	}
 
 	return response, nil

--- a/controller/response.go
+++ b/controller/response.go
@@ -82,7 +82,7 @@ func (r *FileResponse) Write(ctx *gin.Context) {
 	ctx.Header("Etag", r.etag)
 
 	if r.body != nil && (r.statusCode == http.StatusOK || r.statusCode == http.StatusPartialContent) {
-	    safeName := url.QueryEscape(r.name)
+		safeName := url.QueryEscape(r.name)
 		ctx.Writer.Header().Set("Content-Disposition", fmt.Sprintf(`inline; filename="%s"`, safeName))
 
 		_, err := io.Copy(ctx.Writer, r.body)

--- a/controller/response.go
+++ b/controller/response.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -81,7 +82,8 @@ func (r *FileResponse) Write(ctx *gin.Context) {
 	ctx.Header("Etag", r.etag)
 
 	if r.body != nil && (r.statusCode == http.StatusOK || r.statusCode == http.StatusPartialContent) {
-		ctx.Writer.Header().Set("Content-Disposition", fmt.Sprintf(`inline; filename="%s"`, r.name))
+	    safeName := url.QueryEscape(r.name)
+		ctx.Writer.Header().Set("Content-Disposition", fmt.Sprintf(`inline; filename="%s"`, safeName))
 
 		_, err := io.Copy(ctx.Writer, r.body)
 		if err != nil {


### PR DESCRIPTION
## Description

URL-encode filename before setting it to response headers.

## Problem
[HTTP spec](https://www.rfc-editor.org/rfc/rfc7230#section-3.2) suggests that HTTP header should include ASCII character only. If filename contains non-ASCII char, hasura-storage will respond with non-ASCII char in header. This will break the response in some cases (Azure App Service in my case).


## Solution

URL-encode the filename (with `net/url`) before setting it to header.
