### PR TITLE
fix: url-safe filename

### DIFF
--- a/controller/get_file.go
+++ b/controller/get_file.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strconv"
 	"time"
 
@@ -222,7 +223,7 @@ func (ctrl *Controller) getFileProcess(ctx *gin.Context) (*FileResponse, *APIErr
 
 	if response.statusCode == http.StatusOK {
 		// if we want to download files at some point prepend `attachment;` before filename
-		response.headers.Add("Content-Disposition", fmt.Sprintf(`inline; filename="%s"`, fileMetadata.Name))
+		response.headers.Add("Content-Disposition", fmt.Sprintf(`inline; filename="%s"`, url.QueryEscape(fileMetadata.Name)))
 	}
 
 	return response, nil

--- a/controller/response.go
+++ b/controller/response.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -81,7 +82,7 @@ func (r *FileResponse) Write(ctx *gin.Context) {
 	ctx.Header("Etag", r.etag)
 
 	if r.body != nil && (r.statusCode == http.StatusOK || r.statusCode == http.StatusPartialContent) {
-		ctx.Writer.Header().Set("Content-Disposition", fmt.Sprintf(`inline; filename="%s"`, r.name))
+		ctx.Writer.Header().Set("Content-Disposition", fmt.Sprintf(`inline; filename="%s"`, url.QueryEscape(r.name)))
 
 		_, err := io.Copy(ctx.Writer, r.body)
 		if err != nil {


### PR DESCRIPTION
## Description
fix: URL-encode filename before setting it to response headers.


## Problem
[HTTP spec](https://www.rfc-editor.org/rfc/rfc7230#section-3.2) suggests that HTTP header should include ASCII character only. If filename contains non-ASCII char, hasura-storage will respond with non-ASCII char in header. This will break the response in some cases (Azure App Service in my case).

## Solution
URL-encode the filename (with net/url) before setting it to header.
