### PR TITLE
fix: Finetuning openapi doc for better swagger testing

### DIFF
--- a/controller/openapi.yaml
+++ b/controller/openapi.yaml
@@ -152,7 +152,9 @@ paths:
                 file[]:
                   description: Array of files to upload.
                   type: array
-                  items: {}
+                  items:
+                    type: string
+                    format: binary
             encoding:
               file[]:
                 contentType: application/octet-stream


### PR DESCRIPTION
## Description
<!--
Use one of the following title prefix to categorize the pull request:
feat:   mark this pull request as a feature
fix:    mark this pull request as a bug fix
chore:  mark this pull request as a maintenance item
-->
## Problem
When testing hasura-storage through Swagger UI, the POST /file endpoint doesn't allow to browse and pick a file to upload

## Solution
Enriching openapi.yaml with extended property description for the endpoint solves the issue

## Notes
This is a super simple fix, but I hope it may help others 

