### PR TITLE
chore: avoid warning logs with av notification

### DIFF
--- a/build/clamav/clamd.conf.tmpl
+++ b/build/clamav/clamd.conf.tmpl
@@ -10,3 +10,5 @@ StreamMaxLength 1024M
 
 MaxRecursion 16
 MaxFiles 10000
+
+SelfCheck 1800

--- a/build/clamav/freshclam.conf.tmpl
+++ b/build/clamav/freshclam.conf.tmpl
@@ -2,4 +2,3 @@ DatabaseDirectory /clamav/db
 Foreground yes
 DatabaseOwner root
 DatabaseMirror ${DATABASE_MIRROR:-database.clamav.net}
-NotifyClamd yes

--- a/build/dev/docker/docker-compose.yaml
+++ b/build/dev/docker/docker-compose.yaml
@@ -67,7 +67,7 @@ services:
 
   clamd:
     container_name: hasura-storage-clamd
-    image: nhost/clamav:0.1.0
+    image: nhost/clamav:0.1.2
     restart: unless-stopped
     ports:
       - '3310:3310'


### PR DESCRIPTION
There is no need to notify clamav as the `SelfCheck` option is enabled by default. We are making this explicit in the clamav configuration to avoid future confusions.