### PR TITLE
adds a flag for specifying the db name for migrations

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -42,6 +42,7 @@ const (
 	corsAllowOriginsFlag         = "cors-allow-origins"
 	corsAllowCredentialsFlag     = "cors-allow-credentials" //nolint: gosec
 	clamavServerFlag             = "clamav-server"
+	hasuraDbNameFlag             = "hasura-db-name"
 )
 
 func ginLogger(logger *logrus.Logger) gin.HandlerFunc {
@@ -158,6 +159,7 @@ func applymigrations(
 	hasuraMetadata bool,
 	hasuraEndpoint string,
 	hasuraSecret string,
+	hasuraDbName string,
 	logger *logrus.Logger,
 ) {
 	if postgresMigrations {
@@ -174,7 +176,7 @@ func applymigrations(
 
 	if hasuraMetadata {
 		logger.Info("applying hasura metadata")
-		if err := migrations.ApplyHasuraMetadata(hasuraEndpoint, hasuraSecret); err != nil {
+		if err := migrations.ApplyHasuraMetadata(hasuraEndpoint, hasuraSecret, hasuraDbName); err != nil {
 			logger.Errorf("problem applying hasura metadata: %s", err.Error())
 			os.Exit(1)
 		}
@@ -222,6 +224,7 @@ func init() {
 			"",
 			"postgres connection, i.e. postgres://user@pass:localhost:5432/mydb",
 		)
+		addStringFlag(serveCmd.Flags(), hasuraDbNameFlag, "default", "Hasura database name")
 	}
 
 	{
@@ -275,6 +278,7 @@ var serveCmd = &cobra.Command{
 				s3BucketFlag:           viper.GetString(s3BucketFlag),
 				s3RootFolderFlag:       viper.GetString(s3RootFolderFlag),
 				clamavServerFlag:       viper.GetString(clamavServerFlag),
+				hasuraDbNameFlag:       viper.GetString(hasuraDbNameFlag),
 			},
 		).Debug("parameters")
 
@@ -294,6 +298,7 @@ var serveCmd = &cobra.Command{
 			viper.GetBool(hasuraMetadataFlag),
 			viper.GetString(hasuraEndpointFlag),
 			viper.GetString(hasuraAdminSecretFlag),
+			viper.getString(hasuraDbNameFlag),
 			logger,
 		)
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -298,7 +298,7 @@ var serveCmd = &cobra.Command{
 			viper.GetBool(hasuraMetadataFlag),
 			viper.GetString(hasuraEndpointFlag),
 			viper.GetString(hasuraAdminSecretFlag),
-			viper.getString(hasuraDbNameFlag),
+			viper.GetString(hasuraDbNameFlag),
 			logger,
 		)
 

--- a/migrations/hasura.go
+++ b/migrations/hasura.go
@@ -142,11 +142,11 @@ type DropRelationshipArgs struct {
 	Relationship string `json:"relationship"`
 }
 
-func ApplyHasuraMetadata(url, hasuraSecret string) error { //nolint: funlen
+func ApplyHasuraMetadata(url, hasuraSecret, hasuraDbName string) error { //nolint: funlen
 	bucketsTable := TrackTable{
 		Type: "pg_track_table",
 		Args: PgTrackTableArgs{
-			Source: "default",
+			Source: hasuraDbName,
 			Table: Table{
 				Schema: "storage",
 				Name:   "buckets",
@@ -185,7 +185,7 @@ func ApplyHasuraMetadata(url, hasuraSecret string) error { //nolint: funlen
 	filesTable := TrackTable{
 		Type: "pg_track_table",
 		Args: PgTrackTableArgs{
-			Source: "default",
+			Source: hasuraDbName,
 			Table: Table{
 				Schema: "storage",
 				Name:   "files",
@@ -227,7 +227,7 @@ func ApplyHasuraMetadata(url, hasuraSecret string) error { //nolint: funlen
 	virusTable := TrackTable{
 		Type: "pg_track_table",
 		Args: PgTrackTableArgs{
-			Source: "default",
+			Source: hasuraDbName,
 			Table: Table{
 				Schema: "storage",
 				Name:   "virus",
@@ -270,7 +270,7 @@ func ApplyHasuraMetadata(url, hasuraSecret string) error { //nolint: funlen
 				Name:   "files",
 			},
 			Name:   "bucket",
-			Source: "default",
+			Source: hasuraDbName,
 			Using: CreateObjectRelationshipUsing{
 				ForeignKeyConstraintOn: []string{"bucket_id"},
 			},
@@ -289,7 +289,7 @@ func ApplyHasuraMetadata(url, hasuraSecret string) error { //nolint: funlen
 				Name:   "buckets",
 			},
 			Name:   "files",
-			Source: "default",
+			Source: hasuraDbName,
 			Using: CreateArrayRelationshipUsing{
 				ForeignKeyConstraintOn: ForeignKeyConstraintOn{
 					Table: Table{
@@ -314,7 +314,7 @@ func ApplyHasuraMetadata(url, hasuraSecret string) error { //nolint: funlen
 				Name:   "virus",
 			},
 			Name:   "file",
-			Source: "default",
+			Source: hasuraDbName,
 			Using: CreateObjectRelationshipUsing{
 				ForeignKeyConstraintOn: []string{"file_id"},
 			},


### PR DESCRIPTION
## Problem
Currently, it seems that the name of the target database for migrations is fixed to "default." This produces the following error when there is no database named "default":
```
problem applying Hasura metadata: problem adding metadata for the buckets table: status_code: 400\nresponse: {"error":"source with name \"default\" does not exist","path":"$.args","code":"not-exists"}
```
(see https://github.com/nhost/hasura-storage/issues/184#issue-1972012220)

## Solution
To address this issue and provide more flexibility in configuring the target database for migrations, we propose the following solution:

- **Environment Variable**: Introduce a new environment variable named `HASURA_DB_NAME` to allow users to specify the target database name for migrations.

- **Configuration Update**: Modify the code in `hasura-storage/migrations/hasura.go` to use the value of `HASURA_DB_NAME` as the target database name. This ensures that users can configure the target database dynamically.

- **Fallback to "default"**: If `HASURA_DB_NAME` is not set, the code should default to "default" to maintain backward compatibility.

## Notes
- Users can set the `HASURA_DB_NAME` environment variable to configure the target database for migrations to their desired database name.

- This change enhances the flexibility of the migration process, especially in cases where the database name is not "default."

- Reviewers are encouraged to verify that the documentation has been updated to reflect the new configuration option.

With this solution, users can customize the target database for migrations by setting the `HASURA_DB_NAME` environment variable, which eliminates the error associated with the fixed "default" database name.
